### PR TITLE
Use registry URL knative-local-registry:5000/...

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,12 +127,13 @@ kubectl run knative-test-client --image=gcr.io/cloud-builders/curl --restart=Nev
   -H 'Content-Type: text/plain' \
   -d 'Aguid this!' \
   http://knative-ingressgateway.istio-system.svc.cluster.local/
-kubectl wait pod knative-test-client --for=condition=running
+kubectl wait pod knative-test-client --for=condition=initialized --timeout=10s
+kubectl wait pod knative-test-client --for=condition=completed --timeout=5s
 kubectl logs -f knative-test-client
-echo "If the function call worked your response from curl is the deterministic UUID"
+echo "If the function call worked your response from curl is the deterministic UUID:"
 kubectl logs --tail=1 knative-test-client
+echo ""
 kubectl delete pod/knative-test-client
-
 ```
 
 ## TODOs

--- a/README.md
+++ b/README.md
@@ -121,7 +121,10 @@ kubectl describe route.serving.knative.dev/runtime-nodejs-example-module
 To test the route through the cluster's internal name
 
 ```
-kubectl run knative-test-client --image=gcr.io/cloud-builders/curl --restart=Never -- --connect-timeout 3 --retry 10 -vSL http://runtime-nodejs-example-module.default.svc.cluster.local/
+kubectl run knative-test-client --image=gcr.io/cloud-builders/curl --restart=Never -- \
+  --connect-timeout 3 --retry 10 -vSL \
+  -H "Host: runtime-nodejs-example-module.default.example.com" \
+  http://knative-ingressgateway.istio-system.svc.cluster.local/
 kubectl wait pod knative-test-client --for=condition=ready
 kubectl logs -f knative-test-client
 kubectl delete pod/knative-test-client

--- a/README.md
+++ b/README.md
@@ -124,10 +124,15 @@ To test the route through the cluster's internal name
 kubectl run knative-test-client --image=gcr.io/cloud-builders/curl --restart=Never -- \
   --connect-timeout 3 --retry 10 -vSL \
   -H "Host: runtime-nodejs-example-module.default.example.com" \
+  -H 'Content-Type: text/plain' \
+  -d 'Aguid this!' \
   http://knative-ingressgateway.istio-system.svc.cluster.local/
-kubectl wait pod knative-test-client --for=condition=ready
+kubectl wait pod knative-test-client --for=condition=running
 kubectl logs -f knative-test-client
+echo "If the function call worked your response from curl is the deterministic UUID"
+kubectl logs --tail=1 knative-test-client
 kubectl delete pod/knative-test-client
+
 ```
 
 ## TODOs

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ kubectl logs -l serving.knative.dev/configuration=runtime-nodejs-example-module 
 List your revisions:
 
 ```bash
-kubectl get revision.serving.knative.de
+kubectl get revision.serving.knative.dev
 ```
 
 Create a route and use `describe` to see your public and local URL.

--- a/build01.yaml
+++ b/build01.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: default
 spec:
   build:
-    serviceAccountName: build
+    #serviceAccountName: build
     source:
       git:
         url: https://github.com/triggermesh/nodejs-runtime.git
@@ -15,7 +15,7 @@ spec:
       # probably to be replaced with ClusterBuildTemplate: namespace: build-templates
       arguments:
       - name: _IMAGE
-        value: registry.munu.io/solsson/runtime-nodejs-example-module
+        value: knative-local-registry:5000/solsson/runtime-nodejs-example-module
       - name: _ENTRY_POINT
         value: todo-select-language-dependent-entrypoint
       - name: DIRECTORY
@@ -30,7 +30,7 @@ spec:
         # image either provided as pre-built container, or built by Knative Serving from
         # source. When built by knative, set to the same as build template, e.g.
         # build.template.arguments[_IMAGE], as the "promise" of a future build.
-        image: registry.munu.io/solsson/runtime-nodejs-example-module
+        image: knative-local-registry:5000/solsson/runtime-nodejs-example-module
         env:
         - name: SALT
           value: Salt01

--- a/knative-build-template.yaml
+++ b/knative-build-template.yaml
@@ -50,3 +50,4 @@ spec:
     - --context=/workspace/${DIRECTORY}
     - --dockerfile=/workspace/${DIRECTORY}/Dockerfile
     - --destination=${_IMAGE}:${TAG}
+    - --skip-tls-verify


### PR DESCRIPTION
Tested on [minikube](https://github.com/knative/docs/blob/master/install/README.md) with the controller trusted CA patch https://github.com/triggermesh/knative-local-registry/commit/eb5b384f272110910da697502e139e608472b336.

Local registry setup isn't documented yet but it's also not a requirement. I'll merge the PR because to in order to follow this example you need to replace some string with your registry host, so it could just as well be `knative-local-registry:5000`.

After merge I will remove the `--skip-tls-verify` flag because it's dangerous for non-local registries. Anyone can edit the build template to restore the flag.