### PR TITLE
Use local registry without aliases in each namespace

### DIFF
--- a/build-r00001.yaml
+++ b/build-r00001.yaml
@@ -19,7 +19,7 @@ metadata:
   namespace: default
 spec:
   build:
-    serviceAccountName: knative-build
+    #serviceAccountName: knative-build
     source:
       git:
         url: https://github.com/triggermesh/nodejs-runtime.git

--- a/build-r00001.yaml
+++ b/build-r00001.yaml
@@ -29,7 +29,7 @@ spec:
       # probably to be replaced with ClusterBuildTemplate: namespace: build-templates
       arguments:
       - name: IMAGE
-        value: knative-local-registry:5000/runtime-examples/nodejs-module
+        value: knative.registry.svc.cluster.local/runtime-examples/nodejs-module
       - name: _ENTRY_POINT
         value: todo-select-language-dependent-entrypoint
       - name: DIRECTORY
@@ -44,7 +44,7 @@ spec:
         # image either provided as pre-built container, or built by Knative Serving from
         # source. When built by knative, set to the same as build template, e.g.
         # build.template.arguments[IMAGE], as the "promise" of a future build.
-        image: knative-local-registry:5000/runtime-examples/nodejs-module
+        image: knative.registry.svc.cluster.local/runtime-examples/nodejs-module
         env:
         - name: SALT
           value: Salt01

--- a/build-r00002.yaml
+++ b/build-r00002.yaml
@@ -19,7 +19,7 @@ metadata:
   namespace: default
 spec:
   build:
-    serviceAccountName: knative-build
+    #serviceAccountName: knative-build
     source:
       git:
         url: https://github.com/triggermesh/nodejs-runtime.git

--- a/build-r00002.yaml
+++ b/build-r00002.yaml
@@ -29,7 +29,7 @@ spec:
       # probably to be replaced with ClusterBuildTemplate: namespace: build-templates
       arguments:
       - name: IMAGE
-        value: knative-local-registry:5000/runtime-examples/nodejs-module
+        value: knative.registry.svc.cluster.local/runtime-examples/nodejs-module
       - name: _ENTRY_POINT
         value: todo-select-language-dependent-entrypoint
       - name: DIRECTORY
@@ -44,7 +44,7 @@ spec:
         # image either provided as pre-built container, or built by Knative Serving from
         # source. When built by knative, set to the same as build template, e.g.
         # build.template.arguments[IMAGE], as the "promise" of a future build.
-        image: knative-local-registry:5000/runtime-examples/nodejs-module
+        image: knative.registry.svc.cluster.local/runtime-examples/nodejs-module
         env:
         - name: SALT
           value: Salt02

--- a/knative-build-template.yaml
+++ b/knative-build-template.yaml
@@ -31,9 +31,6 @@ spec:
   - name: FUNCTION_NAME
     description: The name of the exported function to put in the runtime (empty to use package.json)
     default: ""
-  - name: SKIP_TLS_VERIFY
-    description: Skip registry TLS verification at push
-    default: "false"
   steps:
   - name: dockerfile
     image: gcr.io/kaniko-project/executor:debug@sha256:5a8d578dc7ff0114daadb20902bf8529f9a2257440d68ac9c6c4b7da98665ca1
@@ -67,4 +64,3 @@ spec:
     - --context=/workspace/${DIRECTORY}
     - --dockerfile=/workspace/${DIRECTORY}/Dockerfile
     - --destination=${IMAGE}:${TAG}
-    - --skip-tls-verify=${SKIP_TLS_VERIFY}


### PR DESCRIPTION
In my tests with Minikube and https://github.com/triggermesh/knative-local-registry/pull/4 we no longer need the patching to accept CA. The scenario in the readme passes as it is.

Knative installed using https://github.com/triggermesh/charts/pull/5.